### PR TITLE
Fix slow nightly tests by cleaning per-test cache, WIP

### DIFF
--- a/.github/workflows/pytest-slow-nightly.yml
+++ b/.github/workflows/pytest-slow-nightly.yml
@@ -1,8 +1,10 @@
 name: Pytest slow nightly
 
-# TODO(roulbac): Set the schedule back to "0 0 * * *" once the tests are stable.
 on:
+  schedule:
+    - cron: "0 6 * * *"
   workflow_dispatch:
+    
 
 jobs:
   pytest-slow:
@@ -27,4 +29,4 @@ jobs:
       - name: pytest
         run: |
           python -m pytest -s -vv -m "slow" .
-        timeout-minutes: 30
+        timeout-minutes: 20

--- a/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2.py
+++ b/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2.py
@@ -29,7 +29,7 @@ def NLP_CONNECT_VIT_GPT2(default: Image) -> DataFrame:
     import transformers
     import torch
     import torchvision.transforms.functional as TF
-    from flojoy import snapshot_download
+    from flojoy import DataFrame, snapshot_download
 
     r, g, b, a = default.r, default.g, default.b, default.a
     nparray = (

--- a/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2_test_.py
+++ b/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2_test_.py
@@ -16,7 +16,10 @@ def obama_image_array_rgb():
 
 @pytest.mark.slow
 def test_NLP_CONNECT_VIT_GPT2(
-    mock_flojoy_decorator, mock_flojoy_cache_directory, obama_image_array_rgb
+    mock_flojoy_decorator,
+    mock_flojoy_venv_cache_directory,
+    cleanup_flojoy_cache_fixture,
+    obama_image_array_rgb,
 ):
     import NLP_CONNECT_VIT_GPT2
 

--- a/AI_ML/PREDICT_TIME_SERIES/PROPHET_PREDICT/PROPHET_PREDICT_test_.py
+++ b/AI_ML/PREDICT_TIME_SERIES/PROPHET_PREDICT/PROPHET_PREDICT_test_.py
@@ -3,7 +3,7 @@ import pandas as pd
 from flojoy import DataFrame
 
 
-def test_PROPHET_PREDICT(mock_flojoy_decorator, mock_flojoy_cache_directory):
+def test_PROPHET_PREDICT(mock_flojoy_decorator, mock_flojoy_venv_cache_directory):
     import PROPHET_PREDICT
 
     # Generate random time series data

--- a/AI_ML/SEGMENTATION/DEEPLAB_V3/DEEPLAB_V3.py
+++ b/AI_ML/SEGMENTATION/DEEPLAB_V3/DEEPLAB_V3.py
@@ -35,10 +35,11 @@ def DEEPLAB_V3(default: Image) -> Image:
 
     import os
     import numpy as np
-    from PIL import Image as PIL_Image
+    import PIL.Image
     import torch
     from torchvision import transforms
     import torchvision.transforms.functional as TF
+    from flojoy import Image
     from flojoy.utils import FLOJOY_CACHE_DIR
 
     # Parse input image
@@ -50,9 +51,12 @@ def DEEPLAB_V3(default: Image) -> Image:
     # Convert input image
     input_image = TF.to_pil_image(nparray).convert("RGB")
     # Set torch hub cache directory
-    torch.hub.set_dir(os.path.join(FLOJOY_CACHE_DIR, "torch_hub"))
+    torch.hub.set_dir(os.path.join(FLOJOY_CACHE_DIR, "cache", "torch_hub"))
     model = torch.hub.load(
-        "pytorch/vision:v0.10.0", "deeplabv3_resnet50", pretrained=True
+        "pytorch/vision:v0.15.2",
+        "deeplabv3_resnet50",
+        pretrained=True,
+        skip_validation=True
     )
     model.eval()
     # Preprocessing
@@ -73,7 +77,7 @@ def DEEPLAB_V3(default: Image) -> Image:
     colors = torch.as_tensor([i for i in range(21)])[:, None] * palette
     colors = (colors % 255).numpy().astype("uint8")
     # plot the semantic segmentation predictions of 21 classes in each color
-    r = PIL_Image.fromarray(output_predictions.byte().cpu().numpy()).resize(
+    r = PIL.Image.fromarray(output_predictions.byte().cpu().numpy()).resize(
         input_image.size
     )
     r.putpalette(colors)

--- a/AI_ML/SEGMENTATION/DEEPLAB_V3/DEEPLAB_V3.py
+++ b/AI_ML/SEGMENTATION/DEEPLAB_V3/DEEPLAB_V3.py
@@ -56,7 +56,7 @@ def DEEPLAB_V3(default: Image) -> Image:
         "pytorch/vision:v0.15.2",
         "deeplabv3_resnet50",
         pretrained=True,
-        skip_validation=True
+        skip_validation=True,
     )
     model.eval()
     # Preprocessing

--- a/AI_ML/SEGMENTATION/DEEPLAB_V3/DEEPLAB_V3_test_.py
+++ b/AI_ML/SEGMENTATION/DEEPLAB_V3/DEEPLAB_V3_test_.py
@@ -9,14 +9,20 @@ from flojoy import Image
 
 @pytest.fixture
 def obama_image_array_rgb():
-    _image_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "assets", "obama_image.jpg")
+    _image_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "assets", "obama_image.jpg"
+    )
     image = PIL_Image.open(_image_path).convert("RGB")
     return np.array(image, copy=True)
 
 
 @pytest.fixture
 def obama_segmentation_array_rgb():
-    _image_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "assets", "obama_segmentation_image.jpg")
+    _image_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "assets",
+        "obama_segmentation_image.jpg",
+    )
     image = PIL_Image.open(_image_path).convert("RGB")
     return np.array(image, copy=True)
 

--- a/AI_ML/SEGMENTATION/DEEPLAB_V3/DEEPLAB_V3_test_.py
+++ b/AI_ML/SEGMENTATION/DEEPLAB_V3/DEEPLAB_V3_test_.py
@@ -9,24 +9,23 @@ from flojoy import Image
 
 @pytest.fixture
 def obama_image_array_rgb():
-    _image_path = (
-        f"{os.path.dirname(os.path.realpath(__file__))}/assets/obama_image.jpg"
-    )
+    _image_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "assets", "obama_image.jpg")
     image = PIL_Image.open(_image_path).convert("RGB")
-    return np.array(image)
+    return np.array(image, copy=True)
 
 
 @pytest.fixture
 def obama_segmentation_array_rgb():
-    _image_path = f"{os.path.dirname(os.path.realpath(__file__))}/assets/obama_segmentation_image.jpg"
+    _image_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "assets", "obama_segmentation_image.jpg")
     image = PIL_Image.open(_image_path).convert("RGB")
-    return np.array(image)
+    return np.array(image, copy=True)
 
 
 @pytest.mark.slow
 def test_DEEPLAB_V3(
     mock_flojoy_decorator,
-    mock_flojoy_cache_directory,
+    mock_flojoy_venv_cache_directory,
+    cleanup_flojoy_cache_fixture,
     obama_image_array_rgb,
     obama_segmentation_array_rgb,
 ):

--- a/AI_ML/TEXT_SUMMARIZATION/BART_LARGE_CNN/BART_LARGE_CNN_test_.py
+++ b/AI_ML/TEXT_SUMMARIZATION/BART_LARGE_CNN/BART_LARGE_CNN_test_.py
@@ -16,9 +16,13 @@ def long_text():
     return text
 
 
-@pytest.mark.skip
 @pytest.mark.slow
-def test_BART_LARGE_CNN(mock_flojoy_decorator, mock_flojoy_cache_directory, long_text):
+def test_BART_LARGE_CNN(
+    mock_flojoy_decorator,
+    mock_flojoy_venv_cache_directory,
+    cleanup_flojoy_cache_fixture,
+    long_text,
+):
     import BART_LARGE_CNN
 
     output = BART_LARGE_CNN.BART_LARGE_CNN(

--- a/EXTRACTORS/FILE/OPEN_IMAGE/OPEN_IMAGE_test_.py
+++ b/EXTRACTORS/FILE/OPEN_IMAGE/OPEN_IMAGE_test_.py
@@ -16,7 +16,7 @@ def obama_image_array_rgb():
 
 @pytest.mark.slow
 def test_OPEN_IMAGE(
-    mock_flojoy_decorator, mock_flojoy_cache_directory, obama_image_array_rgb
+    mock_flojoy_decorator, obama_image_array_rgb
 ):
     import OPEN_IMAGE
 

--- a/EXTRACTORS/FILE/OPEN_IMAGE/OPEN_IMAGE_test_.py
+++ b/EXTRACTORS/FILE/OPEN_IMAGE/OPEN_IMAGE_test_.py
@@ -15,9 +15,7 @@ def obama_image_array_rgb():
 
 
 @pytest.mark.slow
-def test_OPEN_IMAGE(
-    mock_flojoy_decorator, obama_image_array_rgb
-):
+def test_OPEN_IMAGE(mock_flojoy_decorator, obama_image_array_rgb):
     import OPEN_IMAGE
 
     _image_path = f"{os.path.dirname(os.path.realpath(__file__))}/assets/President_Barack_Obama.jpg"

--- a/EXTRACTORS/FILE/OPEN_PARQUET/OPEN_PARQUET_test_.py
+++ b/EXTRACTORS/FILE/OPEN_PARQUET/OPEN_PARQUET_test_.py
@@ -3,7 +3,7 @@ import pytest
 
 
 @pytest.mark.slow
-def test_OPEN_PARQUET(mock_flojoy_decorator, mock_flojoy_cache_directory):
+def test_OPEN_PARQUET(mock_flojoy_decorator):
     import OPEN_PARQUET
 
     _file_path = (

--- a/EXTRACTORS/FILE/READ_S3/READ_S3_test_.py
+++ b/EXTRACTORS/FILE/READ_S3/READ_S3_test_.py
@@ -37,7 +37,6 @@ def mock_keyring_get_password():
 
 def test_READ_S3(
     mock_flojoy_decorator,
-    mock_flojoy_cache_directory,
     mock_bucket,
     mock_keyring_get_password,
     test_dataframe,

--- a/LOADERS/LOCAL_FILE_SYSTEM/OPEN_MATLAB/OPEN_MATLAB_test_.py
+++ b/LOADERS/LOCAL_FILE_SYSTEM/OPEN_MATLAB/OPEN_MATLAB_test_.py
@@ -3,7 +3,7 @@ import pytest
 
 
 @pytest.mark.slow
-def test_OPEN_MATLAB(mock_flojoy_decorator, mock_flojoy_cache_directory):
+def test_OPEN_MATLAB(mock_flojoy_decorator):
     import OPEN_MATLAB
 
     _file_path = f"{os.path.dirname(os.path.realpath(__file__))}/assets/default.mat"

--- a/VISUALIZERS/PLOTLY/PROPHET_COMPONENTS/PROPHET_COMPONENTS_test_.py
+++ b/VISUALIZERS/PLOTLY/PROPHET_COMPONENTS/PROPHET_COMPONENTS_test_.py
@@ -22,7 +22,7 @@ def mock_prophet_output_dataframe():
 
 def test_PROPHET_COMPONENTS(
     mock_flojoy_decorator,
-    mock_flojoy_cache_directory,
+    mock_flojoy_venv_cache_directory,
     mock_prophet_model_json,
     mock_prophet_output_dataframe,
 ):

--- a/VISUALIZERS/PLOTLY/PROPHET_PLOT/PROPHET_PLOT_test_.py
+++ b/VISUALIZERS/PLOTLY/PROPHET_PLOT/PROPHET_PLOT_test_.py
@@ -22,7 +22,7 @@ def mock_prophet_output_dataframe():
 
 def test_PROPHET_PLOT(
     mock_flojoy_decorator,
-    mock_flojoy_cache_directory,
+    mock_flojoy_venv_cache_directory,
     mock_prophet_output_dataframe,
     mock_prophet_model_json,
 ):

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,13 @@
 import pytest
-import tempfile
-from functools import wraps
 from unittest.mock import patch
+
+import os
+import shutil
+import tempfile
+from contextlib import contextmanager
+from functools import wraps
+
+from flojoy.utils import FLOJOY_CACHE_DIR
 
 
 @pytest.fixture
@@ -27,10 +33,60 @@ def mock_flojoy_decorator():
 
 
 @pytest.fixture
-def mock_flojoy_cache_directory():
-    """A fixture that mocks the flojoy cache directory to a temporary directory that is cleaned up automatically after each test function"""
+def mock_flojoy_venv_cache_directory():
+    """A fixture that mocks the flojoy venv cache directory to a temporary directory"""
     with tempfile.TemporaryDirectory() as tempdir:
         with patch(
             "flojoy.flojoy_node_venv._get_venv_cache_dir", return_value=tempdir
         ) as mock_venv_cache_dir:
             yield mock_venv_cache_dir
+
+
+@pytest.fixture
+def cleanup_flojoy_cache_fixture():
+    """A fixture that watches for additions to the flojoy cache directory and deletes them.
+    NOTE: This fixture is not thread-safe. DO NOT run tests in parallel if using this.
+    """
+
+    # Helper functions for watching a directory for changes
+
+    def get_all_paths(directory):
+        """Recursively get all file and directory paths within the directory."""
+        paths = set()
+        for dirpath, dirnames, filenames in os.walk(directory):
+            for filename in filenames:
+                paths.add(os.path.join(dirpath, filename))
+            for dirname in dirnames:
+                paths.add(os.path.join(dirpath, dirname))
+        return paths
+
+    @contextmanager
+    def watch_directory(path):
+        """Watch a directory for changes and yield. After the yield, remove all new files or directories."""
+        # Validate that path is a directory
+        if os.path.exists(path) and not os.path.isdir(path):
+            raise ValueError(f"{path} already exists and is a file")
+
+        try:
+            # Store initial files and directories
+            initial_contents = get_all_paths(path)
+            yield
+        finally:
+            # Store final files and directories
+            final_contents = get_all_paths(path)
+
+            # Find the difference between the two sets, this will be the new files or directories
+            new_contents = final_contents - initial_contents
+
+            # Remove all new files or directories
+            for content in new_contents:
+                if os.path.isfile(content):
+                    os.remove(content)
+                elif os.path.isdir(content) and not os.path.islink(content):
+                    shutil.rmtree(content)
+                else:
+                    # Does not exist
+                    pass
+
+    with watch_directory(FLOJOY_CACHE_DIR):
+        yield

--- a/node_styleguide.md
+++ b/node_styleguide.md
@@ -43,7 +43,7 @@ def test_ADD(mock_flojoy_decorator):
     assert ADD.ADD(1, 2) == 3
 ```
 
-**IMPORTANT** Additionally, if the node under test writes to the Flojoy cache directory (`~/.flojoy`), PLEASE use the `mock_flojoy_cache_directory` fixture (present in `conftest.py`). Any cache written by your test will then be cleaned up once the test finishes running, and that ensures CI testing will not crash due to excessive disk volume usage.
+**IMPORTANT** Additionally, if the node under test writes to the Flojoy cache directory (`~/.flojoy`), PLEASE use the `cleanup_flojoy_cache_fixture` fixture (present in `conftest.py`). Any cache written by your test will then be cleaned up once the test finishes running, and that ensures CI testing will not crash due to excessive disk volume usage.
 
 ### Best practices
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,4 +49,4 @@ xlrd==2.0.1
 pytest==7.4.0
 pytest-test-groups==1.0.3
 pytest-xdist==3.3.1
-flojoy==0.1.5.dev13
+flojoy==0.1.5.dev17

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,4 +49,4 @@ xlrd==2.0.1
 pytest==7.4.0
 pytest-test-groups==1.0.3
 pytest-xdist==3.3.1
-flojoy==0.1.5.dev17
+flojoy==0.1.5.dev18


### PR DESCRIPTION
This PR fixes the issue with hanging github runners. Github actions runners (especially mac) would hang when they run out of disk space, and that is because the models these tests download are very large.

We introduce `cleanup_flojoy_cache_fixture` that records file/folder additions to the `~/.flojoy` cache directory and cleans them up once every running test completes.

NOTE: The tests currently run every 20mins. I will let them run for about a day to observe if we still experience hangs, then past that the schedule will resume to running once a day at midnight UTC.