### PR TITLE
Remove unnecessary pytest caching step, use regular python action caching

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,13 +24,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
-
-      - name: Cache python environment
-        id: cache-python-env
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          cache-dependency-path: requirements.txt
 
       - name: Install dependencies within the environment
         if: steps.cache-python-env.outputs.cache-hit != 'true'


### PR DESCRIPTION
The explicit caching step is unnecessary when we specify `cache-dependency-path: requirements.txt` in the setup python action