### PR TITLE
No more rdatasets

### DIFF
--- a/GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/SCIKIT_LEARN_DATASET.py
+++ b/GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/SCIKIT_LEARN_DATASET.py
@@ -1,12 +1,17 @@
 from typing import Literal
 
 from flojoy import DataFrame, flojoy
-from sklearn.datasets import load_iris
 
 
 @flojoy()
-def SCIKIT_LEARN_DATASET(dataset_name: Literal["iris"] = "iris") -> DataFrame:
-    """The SCIKIT_LEARN_DATASET node retrieves a pandas DataFrame from 'sklearn.datasets', using the provided dataset_key parameter, and returns it wrapped in a DataContainer.
+def SCIKIT_LEARN_DATASET(
+    dataset_name: Literal[
+        "iris", "diabetes", "digits", "linnerud", "wine", "breast_cancer"
+    ] = "iris"
+) -> DataFrame:
+    """The SCIKIT_LEARN_DATASET node retrieves a pandas DataFrame from
+    'sklearn.datasets', using the provided dataset_key parameter, and returns
+    it wrapped in a DataContainer.
 
     Parameters
     ----------
@@ -19,8 +24,40 @@ def SCIKIT_LEARN_DATASET(dataset_name: Literal["iris"] = "iris") -> DataFrame:
     """
 
     if dataset_name == "iris":
-        iris = load_iris(as_frame=True)
-        return DataFrame(df=iris)  # type: ignore
+        from sklearn.datasets import load_iris
+
+        iris = load_iris(as_frame=True, return_X_y=True)
+        return DataFrame(df=iris[0])  # type: ignore
+
+    elif dataset_name == "diabetes":
+        from sklearn.datasets import load_diabetes
+
+        iris = load_diabetes(as_frame=True, return_X_y=True)
+        return DataFrame(df=iris[0])  # type: ignore
+
+    elif dataset_name == "digits":
+        from sklearn.datasets import load_digits
+
+        iris = load_digits(as_frame=True, return_X_y=True)
+        return DataFrame(df=iris[0])  # type: ignore
+
+    elif dataset_name == "linnerud":
+        from sklearn.datasets import load_linnerud
+
+        iris = load_linnerud(as_frame=True, return_X_y=True)
+        return DataFrame(df=iris[0])  # type: ignore
+
+    elif dataset_name == "wine":
+        from sklearn.datasets import load_wine
+
+        iris = load_wine(as_frame=True, return_X_y=True)
+        return DataFrame(df=iris[0])  # type: ignore
+
+    elif dataset_name == "breast_cancer":
+        from sklearn.datasets import load_breast_cancer
+
+        iris = load_breast_cancer(as_frame=True, return_X_y=True)
+        return DataFrame(df=iris[0])  # type: ignore
 
     else:
         raise ValueError(f"Failed to retrieve '{dataset_name}' from rdatasets package!")

--- a/GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/SCIKIT_LEARN_DATASET_test_.py
+++ b/GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/SCIKIT_LEARN_DATASET_test_.py
@@ -1,21 +1,20 @@
-# from flojoy import DataFrame
-#
-#
-#
-# # Tests that the function returns the expected DataFrame when called with the default dataset_key parameter
-# def test_default_dataset_key(mock_flojoy_decorator):
-#     import SCIKIT_LEARN_DATASET
-#
-#     result = SCIKIT_LEARN_DATASET.SCIKIT_LEARN_DATASET()
-#     assert isinstance(result, DataFrame)
-#     assert result.m.equals(data("iris"))
-#
-#
-# # Tests that the function returns the expected DataFrame when called with the 'cars' dataset_key parameter
-# def test_cars_dataset_key(mock_flojoy_decorator):
-#     import SCIKIT_LEARN_DATASET
-#
-#     dataset_key = "cars"
-#     result = SCIKIT_LEARN_DATASET.SCIKIT_LEARN_DATASET(dataset_key=dataset_key)
-#     assert isinstance(result, DataFrame)
-#     assert result.m.equals(data(dataset_key))
+from flojoy import DataFrame
+from sklearn.datasets import load_diabetes, load_iris
+
+
+# Tests that the function returns the expected DataFrame when called with the default dataset_key parameter
+def test_load_iris(mock_flojoy_decorator):
+    import SCIKIT_LEARN_DATASET
+
+    result = SCIKIT_LEARN_DATASET.SCIKIT_LEARN_DATASET(dataset_name="iris")
+    assert isinstance(result, DataFrame)
+    assert result.m.equals(load_iris(as_frame=True, return_X_y=True)[0])
+
+
+# Tests that the function returns the expected DataFrame when called with the 'cars' dataset_key parameter
+def test_load_diabetes(mock_flojoy_decorator):
+    import SCIKIT_LEARN_DATASET
+
+    result = SCIKIT_LEARN_DATASET.SCIKIT_LEARN_DATASET(dataset_name="diabetes")
+    assert isinstance(result, DataFrame)
+    assert result.m.equals(load_diabetes(as_frame=True, return_X_y=True)[0])

--- a/GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/SCIKIT_LEARN_DATASET_test_.py
+++ b/GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/SCIKIT_LEARN_DATASET_test_.py
@@ -2,19 +2,17 @@ from flojoy import DataFrame
 from sklearn.datasets import load_diabetes, load_iris
 
 
-# Tests that the function returns the expected DataFrame when called with the default dataset_key parameter
 def test_load_iris(mock_flojoy_decorator):
     import SCIKIT_LEARN_DATASET
 
-    result = SCIKIT_LEARN_DATASET.SCIKIT_LEARN_DATASET(dataset_name="iris")
+    result = SCIKIT_LEARN_DATASET.SCIKIT_LEARN_DATASET(dataset_name="iris")  # type: ignore
     assert isinstance(result, DataFrame)
     assert result.m.equals(load_iris(as_frame=True, return_X_y=True)[0])
 
 
-# Tests that the function returns the expected DataFrame when called with the 'cars' dataset_key parameter
 def test_load_diabetes(mock_flojoy_decorator):
     import SCIKIT_LEARN_DATASET
 
-    result = SCIKIT_LEARN_DATASET.SCIKIT_LEARN_DATASET(dataset_name="diabetes")
+    result = SCIKIT_LEARN_DATASET.SCIKIT_LEARN_DATASET(dataset_name="diabetes")  # type: ignore
     assert isinstance(result, DataFrame)
     assert result.m.equals(load_diabetes(as_frame=True, return_X_y=True)[0])

--- a/GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/app.json
+++ b/GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/app.json
@@ -2,207 +2,319 @@
     "rfInstance": {
         "nodes": [
             {
-                "width": 150,
-                "height": 150,
-                "id": "R_DATASET-52b424e0-d868-40e9-90c2-992ff9c78e0e",
-                "type": "GENERATORS",
+                "width": 380,
+                "height": 293,
+                "id": "TABLE-014a1790-3c66-424e-b134-3b364494c143",
+                "type": "VISUALIZERS",
                 "data": {
-                    "id": "R_DATASET-52b424e0-d868-40e9-90c2-992ff9c78e0e",
-                    "label": "R DATASET",
-                    "func": "R_DATASET",
-                    "type": "GENERATORS",
-                    "ctrls": {
-                        "dataset_key": {
-                            "type": "select",
-                            "default": "iris",
-                            "options": [
-                                "ability.cov",
-                                "airmiles",
-                                "AirPassengers",
-                                "airquality",
-                                "anscombe",
-                                "attenu",
-                                "attitude",
-                                "austres",
-                                "BJsales",
-                                "BOD",
-                                "cars",
-                                "ChickWeight",
-                                "chickwts",
-                                "co2",
-                                "crimtab",
-                                "discoveries",
-                                "DNase",
-                                "esoph",
-                                "euro",
-                                "EuStockMarkets",
-                                "faithful",
-                                "Formaldehyde",
-                                "freeny",
-                                "HairEyeColor",
-                                "Harman23",
-                                "Harman74",
-                                "Indometh",
-                                "infert",
-                                "InsectSprays",
-                                "iris",
-                                "iris3",
-                                "islands",
-                                "JohnsonJohnson",
-                                "LakeHuron",
-                                "LifeCycleSavings",
-                                "Loblolly",
-                                "longley",
-                                "lynx",
-                                "morley",
-                                "mtcars",
-                                "nhtemp",
-                                "Nile",
-                                "nottem",
-                                "npk",
-                                "occupationalStatus",
-                                "Orange",
-                                "OrchardSprays",
-                                "PlantGrowth",
-                                "precip",
-                                "presidents",
-                                "pressure",
-                                "Puromycin",
-                                "quakes",
-                                "randu",
-                                "rivers",
-                                "rock",
-                                "Seatbelts",
-                                "sleep",
-                                "stackloss",
-                                "sunspot.month",
-                                "sunspot.year",
-                                "sunspots",
-                                "swiss",
-                                "Theoph",
-                                "Titanic",
-                                "ToothGrowth",
-                                "treering",
-                                "trees",
-                                "UCBAdmissions",
-                                "UKDriverDeaths",
-                                "UKgas",
-                                "USAccDeaths",
-                                "USArrests",
-                                "USJudgeRatings",
-                                "USPersonalExpenditure",
-                                "VADeaths",
-                                "volcano",
-                                "warpbreaks",
-                                "women",
-                                "WorldPhones",
-                                "WWWusage"
-                            ],
-                            "functionName": "R_DATASET",
-                            "param": "dataset_key",
-                            "value": "iris"
+                    "id": "TABLE-014a1790-3c66-424e-b134-3b364494c143",
+                    "label": "TABLE",
+                    "func": "TABLE",
+                    "type": "VISUALIZERS",
+                    "ctrls": {},
+                    "initCtrls": {},
+                    "inputs": [
+                        {
+                            "name": "default",
+                            "id": "default",
+                            "type": "OrderedTriple|OrderedPair|DataFrame|Vector",
+                            "multiple": false,
+                            "desc": "the DataContainer to be visualized"
                         }
-                    },
+                    ],
                     "outputs": [
                         {
                             "name": "default",
                             "id": "default",
-                            "type": "DataFrame"
+                            "type": "Plotly",
+                            "desc": "the DataContainer containing the Plotly Table visualization"
                         }
                     ],
-                    "pip_dependencies": [
-                        {
-                            "name": "rdatasets",
-                            "v": "0.1.0"
-                        }
-                    ],
-                    "path": "PYTHON/nodes\\GENERATORS\\SAMPLE_DATASETS\\R_DATASET\\R_DATASET.py",
+                    "path": "VISUALIZERS/PLOTLY/TABLE/TABLE.py",
                     "selected": false
                 },
                 "position": {
-                    "x": 128.51593747608803,
-                    "y": 199.87310163004685
+                    "x": 493.4591821594079,
+                    "y": 192.31503238809222
                 },
                 "selected": false,
                 "positionAbsolute": {
-                    "x": 128.51593747608803,
-                    "y": 199.87310163004685
+                    "x": 493.4591821594079,
+                    "y": 192.31503238809222
                 },
                 "dragging": true
             },
             {
                 "width": 380,
                 "height": 293,
-                "id": "TABLE-09b6e8ee-fa4a-43d0-b7d8-4ea7f6678fcd",
+                "id": "TABLE-9b2e5421-635c-4b38-afc0-1c128b2c6d73",
                 "type": "VISUALIZERS",
                 "data": {
-                    "id": "TABLE-09b6e8ee-fa4a-43d0-b7d8-4ea7f6678fcd",
-                    "label": "TABLE",
+                    "id": "TABLE-9b2e5421-635c-4b38-afc0-1c128b2c6d73",
+                    "label": "TABLE 1",
                     "func": "TABLE",
                     "type": "VISUALIZERS",
                     "ctrls": {},
+                    "initCtrls": {},
                     "inputs": [
                         {
                             "name": "default",
                             "id": "default",
-                            "type": "OrderedTriple|OrderedPair|DataFrame",
-                            "multiple": false
+                            "type": "OrderedTriple|OrderedPair|DataFrame|Vector",
+                            "multiple": false,
+                            "desc": "the DataContainer to be visualized"
                         }
                     ],
                     "outputs": [
                         {
                             "name": "default",
                             "id": "default",
-                            "type": "Plotly"
+                            "type": "Plotly",
+                            "desc": "the DataContainer containing the Plotly Table visualization"
                         }
                     ],
-                    "path": "PYTHON/nodes\\VISUALIZERS\\PLOTLY\\TABLE\\TABLE.py",
+                    "path": "VISUALIZERS/PLOTLY/TABLE/TABLE.py",
                     "selected": false
                 },
                 "position": {
-                    "x": 539.9445089046594,
-                    "y": 128.4445302014754
+                    "x": 518.7712883355172,
+                    "y": -132.74472501832986
                 },
                 "selected": false,
                 "positionAbsolute": {
-                    "x": 539.9445089046594,
-                    "y": 128.4445302014754
+                    "x": 518.7712883355172,
+                    "y": -132.74472501832986
+                },
+                "dragging": true
+            },
+            {
+                "width": 380,
+                "height": 293,
+                "id": "TABLE-90d658d2-73b2-4f06-81ec-26c65db46fd2",
+                "type": "VISUALIZERS",
+                "data": {
+                    "id": "TABLE-90d658d2-73b2-4f06-81ec-26c65db46fd2",
+                    "label": "TABLE 2",
+                    "func": "TABLE",
+                    "type": "VISUALIZERS",
+                    "ctrls": {},
+                    "initCtrls": {},
+                    "inputs": [
+                        {
+                            "name": "default",
+                            "id": "default",
+                            "type": "OrderedTriple|OrderedPair|DataFrame|Vector",
+                            "multiple": false,
+                            "desc": "the DataContainer to be visualized"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "default",
+                            "id": "default",
+                            "type": "Plotly",
+                            "desc": "the DataContainer containing the Plotly Table visualization"
+                        }
+                    ],
+                    "path": "VISUALIZERS/PLOTLY/TABLE/TABLE.py",
+                    "selected": false
+                },
+                "position": {
+                    "x": 499.92077094681764,
+                    "y": -460.0160929303845
+                },
+                "selected": false,
+                "positionAbsolute": {
+                    "x": 499.92077094681764,
+                    "y": -460.0160929303845
+                },
+                "dragging": true
+            },
+            {
+                "width": 208,
+                "height": 116,
+                "id": "SCIKIT_LEARN_DATASET-e8f2d84f-c945-4286-a405-f58ef2882ecc",
+                "type": "GENERATORS",
+                "data": {
+                    "id": "SCIKIT_LEARN_DATASET-e8f2d84f-c945-4286-a405-f58ef2882ecc",
+                    "label": "SCIKIT LEARN DATASET (IRIS)",
+                    "func": "SCIKIT_LEARN_DATASET",
+                    "type": "GENERATORS",
+                    "ctrls": {
+                        "dataset_name": {
+                            "type": "select",
+                            "options": [
+                                "iris",
+                                "diabetes",
+                                "digits",
+                                "linnerud",
+                                "wine",
+                                "breast_cancer"
+                            ],
+                            "default": "iris",
+                            "desc": null,
+                            "overload": null,
+                            "functionName": "SCIKIT_LEARN_DATASET",
+                            "param": "dataset_name",
+                            "value": "iris"
+                        }
+                    },
+                    "initCtrls": {},
+                    "outputs": [
+                        {
+                            "name": "default",
+                            "id": "default",
+                            "type": "DataFrame",
+                            "desc": "A DataContainer object containing the retrieved pandas DataFrame."
+                        }
+                    ],
+                    "path": "GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/SCIKIT_LEARN_DATASET.py",
+                    "selected": false
+                },
+                "position": {
+                    "x": 89.90415311013689,
+                    "y": -387.53214708521534
+                },
+                "selected": false,
+                "positionAbsolute": {
+                    "x": 89.90415311013689,
+                    "y": -387.53214708521534
+                },
+                "dragging": true
+            },
+            {
+                "width": 210,
+                "height": 116,
+                "id": "SCIKIT_LEARN_DATASET-35cb3770-2baa-40ec-b808-e6477f798e77",
+                "type": "GENERATORS",
+                "data": {
+                    "id": "SCIKIT_LEARN_DATASET-35cb3770-2baa-40ec-b808-e6477f798e77",
+                    "label": "SCIKIT LEARN DATASET (DIABETES)",
+                    "func": "SCIKIT_LEARN_DATASET",
+                    "type": "GENERATORS",
+                    "ctrls": {
+                        "dataset_name": {
+                            "type": "select",
+                            "options": [
+                                "iris",
+                                "diabetes",
+                                "digits",
+                                "linnerud",
+                                "wine",
+                                "breast_cancer"
+                            ],
+                            "default": "iris",
+                            "desc": null,
+                            "overload": null,
+                            "functionName": "SCIKIT_LEARN_DATASET",
+                            "param": "dataset_name",
+                            "value": "diabetes"
+                        }
+                    },
+                    "initCtrls": {},
+                    "outputs": [
+                        {
+                            "name": "default",
+                            "id": "default",
+                            "type": "DataFrame",
+                            "desc": "A DataContainer object containing the retrieved pandas DataFrame."
+                        }
+                    ],
+                    "path": "GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/SCIKIT_LEARN_DATASET.py",
+                    "selected": false
+                },
+                "position": {
+                    "x": 89.49782717955932,
+                    "y": -55.581944075519544
+                },
+                "selected": false,
+                "positionAbsolute": {
+                    "x": 89.49782717955932,
+                    "y": -55.581944075519544
+                },
+                "dragging": true
+            },
+            {
+                "width": 208,
+                "height": 116,
+                "id": "SCIKIT_LEARN_DATASET-5985e786-bc1b-49e7-9e38-618a24279ddd",
+                "type": "GENERATORS",
+                "data": {
+                    "id": "SCIKIT_LEARN_DATASET-5985e786-bc1b-49e7-9e38-618a24279ddd",
+                    "label": "SCIKIT LEARN DATASET (DIGITS)",
+                    "func": "SCIKIT_LEARN_DATASET",
+                    "type": "GENERATORS",
+                    "ctrls": {
+                        "dataset_name": {
+                            "type": "select",
+                            "options": [
+                                "iris",
+                                "diabetes",
+                                "digits",
+                                "linnerud",
+                                "wine",
+                                "breast_cancer"
+                            ],
+                            "default": "iris",
+                            "desc": null,
+                            "overload": null,
+                            "functionName": "SCIKIT_LEARN_DATASET",
+                            "param": "dataset_name",
+                            "value": "digits"
+                        }
+                    },
+                    "initCtrls": {},
+                    "outputs": [
+                        {
+                            "name": "default",
+                            "id": "default",
+                            "type": "DataFrame",
+                            "desc": "A DataContainer object containing the retrieved pandas DataFrame."
+                        }
+                    ],
+                    "path": "GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/SCIKIT_LEARN_DATASET.py",
+                    "selected": true
+                },
+                "position": {
+                    "x": 87.50801776829911,
+                    "y": 285.2650393430134
+                },
+                "selected": true,
+                "positionAbsolute": {
+                    "x": 87.50801776829911,
+                    "y": 285.2650393430134
                 },
                 "dragging": true
             }
         ],
         "edges": [
             {
-                "source": "R_DATASET-52b424e0-d868-40e9-90c2-992ff9c78e0e",
+                "source": "SCIKIT_LEARN_DATASET-e8f2d84f-c945-4286-a405-f58ef2882ecc",
                 "sourceHandle": "default",
-                "target": "TABLE-09b6e8ee-fa4a-43d0-b7d8-4ea7f6678fcd",
+                "target": "TABLE-90d658d2-73b2-4f06-81ec-26c65db46fd2",
                 "targetHandle": "default",
-                "id": "reactflow__edge-R_DATASET-52b424e0-d868-40e9-90c2-992ff9c78e0edefault-TABLE-09b6e8ee-fa4a-43d0-b7d8-4ea7f6678fcddefault"
+                "id": "reactflow__edge-SCIKIT_LEARN_DATASET-e8f2d84f-c945-4286-a405-f58ef2882eccdefault-TABLE-90d658d2-73b2-4f06-81ec-26c65db46fd2default"
+            },
+            {
+                "source": "SCIKIT_LEARN_DATASET-35cb3770-2baa-40ec-b808-e6477f798e77",
+                "sourceHandle": "default",
+                "target": "TABLE-9b2e5421-635c-4b38-afc0-1c128b2c6d73",
+                "targetHandle": "default",
+                "id": "reactflow__edge-SCIKIT_LEARN_DATASET-35cb3770-2baa-40ec-b808-e6477f798e77default-TABLE-9b2e5421-635c-4b38-afc0-1c128b2c6d73default"
+            },
+            {
+                "source": "SCIKIT_LEARN_DATASET-5985e786-bc1b-49e7-9e38-618a24279ddd",
+                "sourceHandle": "default",
+                "target": "TABLE-014a1790-3c66-424e-b134-3b364494c143",
+                "targetHandle": "default",
+                "id": "reactflow__edge-SCIKIT_LEARN_DATASET-5985e786-bc1b-49e7-9e38-618a24279ddddefault-TABLE-014a1790-3c66-424e-b134-3b364494c143default"
             }
         ],
         "viewport": {
-            "x": -296.35399545928726,
-            "y": 66.8470830817738,
-            "zoom": 0.8744723800359967
+            "x": 669.537650867023,
+            "y": 395.1114317341454,
+            "zoom": 0.7467072297113905
         }
     },
-    "ctrlsManifest": [
-        {
-            "type": "input",
-            "name": "Slider",
-            "id": "INPUT_PLACEHOLDER",
-            "hidden": false,
-            "minHeight": 1,
-            "minWidth": 2,
-            "layout": {
-                "x": 0,
-                "y": 0,
-                "h": 2,
-                "w": 2,
-                "minH": 1,
-                "minW": 2,
-                "i": "INPUT_PLACEHOLDER"
-            }
-        }
-    ]
+    "textNodes": []
 }

--- a/GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/example.md
+++ b/GENERATORS/SAMPLE_DATASETS/SCIKIT_LEARN_DATASET/example.md
@@ -1,9 +1,7 @@
-## The R_DATASET app
+## The SCIKIT_LEARN_DATASET app
 
 The workflow of this app is described below:
 
-[R_DATASET](https://github.com/flojoy-io/nodes/blob/main/GENERATORS/SAMPLE_DATASET/R_DATASET/R_DATASET.py) : This is a R Dataset node. It takes one parameter  `dataset_key`, the name of dataset to load from [`rdatasets`](https://github.com/vincentarelbundock/Rdatasets/tree/master/csv/datasets) package. In this case it is 'iris' which is default value of this parameter. It passing a `DataFrame` object of `DataContainer` class to the next node `Table`.
+[SCIKIT_LEARN_DATASET](https://github.com/flojoy-io/nodes/blob/main/GENERATORS/SAMPLE_DATASET/SCIKIT_LEARN_DATASET/SCIKIT_LEARN_DATASET.py) : This is a SCIKIT_LEARN_DATASET node. It takes one parameter `dataset_name`, the name of dataset to load from [`sklearn.datasets`](https://scikit-learn.org/stable/datasets/toy_dataset.html) package. In this case it is 'iris' which is default value of this parameter. It passing a `DataFrame` object of `DataContainer` class to the next node `Table`.
 
-[TABLE](https://github.com/flojoy-io/nodes/blob/main/VISUALIZERS/PLOTLY/TABLE/TABLE.py): This node creates a Plotly table visualization for a given input `DataFrame` object of `DatacContainer` class.
-
-[TERMINATE](https://github.com/flojoy-io/nodes/blob/main/LOGIC_GATES/TERMINATORS/END/END.py): This node terminating the current script run. The output of this node is same as its parent node.
+[TABLE](https://github.com/flojoy-io/nodes/blob/main/VISUALIZERS/PLOTLY/TABLE/TABLE.py): This node creates a Plotly table visualization for a given input `DataFrame` object of `DataContainer` class.


### PR DESCRIPTION
### Description

- [ ] I've included a concise description of what each node does

### Styleguide

- [ ] My node adheres to the [styleguide](https://github.com/flojoy-io/nodes/blob/main/node_styleguide.md) for Flojoy nodes

### Docs

- [ ] I've submitted a PR for a documentation page for the new node(s) that contains usage examples (see docs.flojoy.io)

### Testing

- [ ] This PR includes a unit test ([example here](https://github.com/flojoy-io/nodes/blob/c28808f2d0aec8f116cdb3fccb46c4f5256574e9/TRANSFORMERS/ARITHMETIC/ADD/ADD_test_.py) and/or ideally a screenshot of the node's output on an example app.
